### PR TITLE
fix(docs): allow required dependency build scripts

### DIFF
--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  esbuild: true
+  sharp: true


### PR DESCRIPTION
## Summary

- Allow the `esbuild` and `sharp` install scripts required by the documentation build.
- Make frozen pnpm installs complete under the repository-pinned pnpm 11 release.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm types:check`
- `pnpm build`
- `git diff --check`