### PR TITLE
fix(component): prefer minimal Wasmtime for AOT compilation

### DIFF
--- a/docs/content/docs/component-service.mdx
+++ b/docs/content/docs/component-service.mdx
@@ -36,7 +36,7 @@ For the Kotlin/Wasm WASI sample, the build order is:
 3. `wasm-tools component embed` embeds the WIT world.
 4. `wasm-tools component new --adapt wasi_snapshot_preview1=...` creates the raw Component.
 5. `wasm-tools validate` and `wasm-tools component wit` verify the result.
-6. The full Wasmtime CLI compiles the raw Component into the configured `.cwasm` and `.pwasm` targets.
+6. A compile-capable Wasmtime CLI compiles the raw Component into the configured `.cwasm` and `.pwasm` targets. The fork's `cranelift-min` CLI is the default; full CLIs are fallbacks.
 7. The manifest records `COMPONENT_MODEL`, `WASMLINE_SERVICE`, the fixed export path, codec, protocol version, target compiler version, and artifact digest.
 
 The Gradle entry point is `wasmlineAssembleDebug` or

--- a/docs/content/docs/component-service.zh.mdx
+++ b/docs/content/docs/component-service.zh.mdx
@@ -36,7 +36,7 @@ Kotlin/Wasm WASI sample 的顺序是：
 3. `wasm-tools component embed` 嵌入 WIT world。
 4. `wasm-tools component new --adapt wasi_snapshot_preview1=...` 生成 raw Component。
 5. `wasm-tools validate` 与 `wasm-tools component wit` 校验产物。
-6. 完整 Wasmtime CLI 将 raw Component 编译为已配置目标的 `.cwasm` 和 `.pwasm`。
+6. 具备编译能力的 Wasmtime CLI 将 raw Component 编译为已配置目标的 `.cwasm` 和 `.pwasm`。默认使用 fork 的 `cranelift-min` CLI，完整 CLI 作为后备方案。
 7. manifest 记录 `COMPONENT_MODEL`、`WASMLINE_SERVICE`、固定 export path、codec、协议版本、目标编译器版本和产物 digest。
 
 Gradle 入口是 `wasmlineAssembleDebug` 或 `wasmlineAssembleRelease`。CLI 通过

--- a/docs/content/docs/gradle-plugin.mdx
+++ b/docs/content/docs/gradle-plugin.mdx
@@ -48,7 +48,7 @@ This page covers all 15 user-facing tasks defined by the plugin.
 |---|---|
 | `checkWasmlineToolchain` | Check the minimal Wasmtime toolchain used by Core Wasm packaging |
 | `wasmlineDownloadWasmtime` | Download the minimal Wasmtime toolchain |
-| `wasmlineDownloadWasmtimeCompiler` | Download the full Wasmtime CLI used for Component AOT compilation |
+| `wasmlineDownloadWasmtimeCompiler` | Download the minimal Cranelift CLI used for Component AOT compilation |
 | `wasmlineDownloadComponentTools` | Download `wit-bindgen`, `wasm-tools`, and the WASI Preview 1 adapter |
 | `generateWasmlineManifestKeyPairEd25519` | Generate an Ed25519 manifest signing key pair |
 | `generateWasmlineManifestKeyPairEcdsaP256` | Generate an ECDSA P-256 manifest signing key pair |

--- a/docs/content/docs/gradle-plugin.zh.mdx
+++ b/docs/content/docs/gradle-plugin.zh.mdx
@@ -48,7 +48,7 @@ wasmline {
 |---|---|
 | `checkWasmlineToolchain` | 检查 Core Wasm 打包使用的精简 Wasmtime 工具链 |
 | `wasmlineDownloadWasmtime` | 下载精简 Wasmtime 工具链 |
-| `wasmlineDownloadWasmtimeCompiler` | 下载 Component AOT 编译使用的完整 Wasmtime CLI |
+| `wasmlineDownloadWasmtimeCompiler` | 下载 Component AOT 编译使用的精简 Cranelift CLI |
 | `wasmlineDownloadComponentTools` | 下载 `wit-bindgen`、`wasm-tools` 和 WASI Preview 1 adapter |
 | `generateWasmlineManifestKeyPairEd25519` | 生成 Ed25519 清单签名密钥对 |
 | `generateWasmlineManifestKeyPairEcdsaP256` | 生成 ECDSA P-256 清单签名密钥对 |

--- a/docs/content/docs/wasmtime-download.mdx
+++ b/docs/content/docs/wasmtime-download.mdx
@@ -1,16 +1,20 @@
 ---
 title: Wasmtime Toolchains
-description: Configure and download the minimal runtime compiler and full Component compiler
+description: Configure the minimal Cranelift compiler with a full CLI fallback
 ---
 
 # Wasmtime Toolchains
 
-The Gradle plugin uses two Wasmtime distributions:
+The Gradle plugin uses the fork's reduced Cranelift CLI by default for both AOT pipelines:
 
-| Distribution | Purpose | Default cache |
+| Toolchain | Purpose | Default cache |
 |---|---|---|
-| Minimal Wasmtime | Core Wasm AOT packaging | `~/.wasmline/wasmtime` |
-| Full Wasmtime CLI | Component AOT compilation | `~/.wasmline/wasmtime-compiler` |
+| Cranelift minimal CLI | Core Wasm AOT packaging | `~/.wasmline/wasmtime` |
+| Cranelift minimal CLI | Component AOT compilation | `~/.wasmline/wasmtime-compiler` |
+
+The `cranelift-min` CLI includes `compile`, Component Model, and Pulley support, so it can emit both Cranelift `.cwasm` and portable Pulley `.pwasm` artifacts. Full Cranelift and Pulley CLIs also provide `compile`, but they are only fallbacks because the minimal Cranelift archive is smaller and already covers both output formats. Pulley minimal releases contain only C API assets and are never selected as build-time CLI compilers.
+
+Release variants are identified by archive names such as `*-min` and `*-pulley`. The executable inside these CLI archives is named `wasmtime`, so Wasmline verifies the executable's version and `compile` capability instead of inferring capabilities from its filename.
 
 ## Configuration
 
@@ -31,7 +35,7 @@ wasmline {
 
 `directory` can set the minimal Wasmtime cache or executable directory. If it is not set, the plugin checks `WASMTIME_ROOT` and then `~/.wasmline/wasmtime`.
 
-`compilerDirectory`, `compilerVersion`, and `compilerExecutable` configure the full Wasmtime CLI used by Component AOT compilation.
+`compilerDirectory`, `compilerVersion`, and `compilerExecutable` configure the CLI used by Component AOT compilation. Automatic downloads select `cranelift-min`; `compilerExecutable` may explicitly select any compile-capable minimal or full CLI. Wasmline verifies the exact version and the `compile` subcommand before compiling.
 
 ## Manual Tasks
 
@@ -42,7 +46,7 @@ wasmline {
 # Download the minimal Wasmtime distribution
 ./gradlew wasmlineDownloadWasmtime
 
-# Download the full Wasmtime CLI
+# Download the minimal Component AOT compiler
 ./gradlew wasmlineDownloadWasmtimeCompiler
 
 # Download wit-bindgen, wasm-tools, and the WASI adapter
@@ -50,6 +54,8 @@ wasmline {
 ```
 
 The assemble tasks invoke the required checks and downloads when `autoDownload` is enabled. See the [Gradle Plugin reference](/en/docs/gradle-plugin) for the complete task list.
+
+The standalone CLI still supports `wasmline download --distribution full` when the full Cranelift fallback is required. An existing full Pulley CLI can be selected explicitly through `compilerExecutable`.
 
 ## Diagnostics
 

--- a/docs/content/docs/wasmtime-download.zh.mdx
+++ b/docs/content/docs/wasmtime-download.zh.mdx
@@ -1,16 +1,20 @@
 ---
 title: Wasmtime 工具链
-description: 配置并下载精简运行时编译器与完整 Component 编译器
+description: 配置精简 Cranelift 编译器与完整 CLI 后备方案
 ---
 
 # Wasmtime 工具链
 
-Gradle 插件使用两种 Wasmtime 发行包：
+Gradle 插件默认在两条 AOT 流水线中使用 fork 提供的精简 Cranelift CLI：
 
-| 发行包 | 用途 | 默认缓存目录 |
+| 工具链 | 用途 | 默认缓存目录 |
 |---|---|---|
-| 精简 Wasmtime | Core Wasm AOT 打包 | `~/.wasmline/wasmtime` |
-| 完整 Wasmtime CLI | Component AOT 编译 | `~/.wasmline/wasmtime-compiler` |
+| 精简 Cranelift CLI | Core Wasm AOT 打包 | `~/.wasmline/wasmtime` |
+| 精简 Cranelift CLI | Component AOT 编译 | `~/.wasmline/wasmtime-compiler` |
+
+`cranelift-min` CLI 包含 `compile`、Component Model 和 Pulley 支持，因此既能生成 Cranelift `.cwasm`，也能生成可移植的 Pulley `.pwasm`。完整 Cranelift 和 Pulley CLI 同样提供 `compile`，但它们仅作为后备方案，因为精简 Cranelift 压缩包体积更小，并且已经覆盖两种输出格式。Pulley minimal release 只包含 C API 产物，绝不会被选为构建期 CLI 编译器。
+
+release 变体通过 `*-min`、`*-pulley` 等压缩包名称区分。这些 CLI 压缩包内的可执行文件都名为 `wasmtime`，因此 Wasmline 会校验可执行文件的版本和 `compile` 能力，而不会根据文件名推断能力。
 
 ## 配置
 
@@ -31,7 +35,7 @@ wasmline {
 
 `directory` 可用于指定精简 Wasmtime 的缓存目录或可执行文件目录。未设置时，插件依次检查 `WASMTIME_ROOT` 和 `~/.wasmline/wasmtime`。
 
-`compilerDirectory`、`compilerVersion` 和 `compilerExecutable` 用于配置 Component AOT 编译使用的完整 Wasmtime CLI。
+`compilerDirectory`、`compilerVersion` 和 `compilerExecutable` 用于配置 Component AOT 编译使用的 CLI。自动下载选择 `cranelift-min`；`compilerExecutable` 可以显式指定任意具备编译能力的 minimal 或完整 CLI。Wasmline 会在编译前校验精确版本和 `compile` 子命令。
 
 ## 手动任务
 
@@ -42,7 +46,7 @@ wasmline {
 # 下载精简 Wasmtime 发行包
 ./gradlew wasmlineDownloadWasmtime
 
-# 下载完整 Wasmtime CLI
+# 下载精简 Component AOT 编译器
 ./gradlew wasmlineDownloadWasmtimeCompiler
 
 # 下载 wit-bindgen、wasm-tools 和 WASI adapter
@@ -50,6 +54,8 @@ wasmline {
 ```
 
 启用 `autoDownload` 时，assemble 任务会自动执行所需的检查与下载。完整任务清单参见 [Gradle 插件参考](/zh/docs/gradle-plugin)。
+
+确实需要完整 Cranelift 后备 CLI 时，独立 CLI 仍支持 `wasmline download --distribution full`。已有的完整 Pulley CLI 可以通过 `compilerExecutable` 显式指定。
 
 ## 诊断
 

--- a/wasmline-multiplatform/docs/design-mind.md
+++ b/wasmline-multiplatform/docs/design-mind.md
@@ -156,12 +156,12 @@ WIT and guest source
   -> Core Wasm guest
   -> wasm-tools component embed/new
   -> raw Component Wasm
-  -> full Wasmtime CLI compile
+  -> compile-capable Wasmtime CLI
   -> Component CWASM/PWASM targets
   -> signed manifest and package
 ```
 
-The raw Component is an intermediate build result, not a native runtime artifact. Component AOT compilation verifies the exact full Wasmtime CLI version and rejects iOS CWASM targets in favor of `pulley64`.
+The raw Component is an intermediate build result, not a native runtime artifact. Component AOT compilation uses the fork's `cranelift-min` CLI by default, accepts compile-capable full CLIs as fallbacks, verifies the exact Wasmtime version and `compile` capability, and rejects iOS CWASM targets in favor of `pulley64`.
 
 ### Runtime
 

--- a/wasmline-multiplatform/wasmline-cli/src/main/kotlin/crow/wasmline/cli/ComponentAotCliSupport.kt
+++ b/wasmline-multiplatform/wasmline-cli/src/main/kotlin/crow/wasmline/cli/ComponentAotCliSupport.kt
@@ -42,7 +42,7 @@ internal class ComponentAotCliAdapter(
 ) {
     constructor(logger: (String) -> Unit = {}) : this(
         compilerResolver = ComponentAotCompilerResolver { directory, version ->
-            WasmtimeCompiler.findWasmtimeCompilerInDirectory(directory, version = version)
+            WasmtimeCompiler.findComponentCompilerInDirectory(directory, version = version)
         },
         pipelineRunner = ComponentAotPipelineRunner { rawComponent, componentDirectory, request ->
             ComponentAotPipeline(ComponentCompiler(logger)).compile(
@@ -56,9 +56,9 @@ internal class ComponentAotCliAdapter(
     fun compile(request: ComponentAotCliRequest): ComponentAotCliResult {
         val compiler = compilerResolver.resolve(request.wasmtimeDirectory, request.wasmtimeVersion)
             ?: error(
-                "Component AOT requires the full Wasmtime ${request.wasmtimeVersion} CLI in " +
+                "Component AOT requires a Wasmtime ${request.wasmtimeVersion} CLI in " +
                     request.wasmtimeDirectory.absolutePath +
-                    ". wasmtime-min is runtime-only; use 'wasmline download --distribution full'.",
+                    ". Download the Cranelift minimal distribution or configure another compile-capable CLI.",
             )
         val outputDirectory = request.outputDirectory.apply {
             check(exists() || mkdirs()) { "Unable to create Component AOT output directory: $absolutePath" }

--- a/wasmline-multiplatform/wasmline-cli/src/main/kotlin/crow/wasmline/cli/Download.kt
+++ b/wasmline-multiplatform/wasmline-cli/src/main/kotlin/crow/wasmline/cli/Download.kt
@@ -33,7 +33,7 @@ internal class Download : CliktCommand(name = "download") {
 
     private val distributionName by option("--distribution")
         .default(DEFAULT_WASMTIME_DISTRIBUTION.name.lowercase())
-        .help("Wasmtime asset kind: minimal (runtime) or full (build compiler)")
+        .help("Wasmtime asset kind: minimal (default Cranelift compiler) or full (Cranelift fallback)")
 
     private val showTokenStatus by option("--show-token-status", hidden = true).flag(default = false)
 

--- a/wasmline-multiplatform/wasmline-cli/src/test/kotlin/crow/wasmline/cli/ComponentAotCliSupportTest.kt
+++ b/wasmline-multiplatform/wasmline-cli/src/test/kotlin/crow/wasmline/cli/ComponentAotCliSupportTest.kt
@@ -19,29 +19,29 @@ private const val FIXTURE_WASM_TOOLS_VERSION = "0.0.0-test"
 
 class ComponentAotCliSupportTest {
     @Test
-    fun `resolves exact full compiler and returns only component aot artifacts`() = withCliAotDirectory { root ->
+    fun `resolves exact component compiler and returns only component aot artifacts`() = withCliAotDirectory { root ->
         val component = File(root, "component/plugin.component.wasm").apply {
             parentFile.mkdirs()
             writeBytes(byteArrayOf(1, 2, 3))
         }
         val rawRecord = rawRecord(component)
-        val fullCompiler = File(root, "wasmtime/wasmtime").apply {
+        val componentCompiler = File(root, "wasmtime/wasmtime-min").apply {
             parentFile.mkdirs()
-            writeText("full")
+            writeText("minimal")
         }
         var resolvedVersion: String? = null
         var pipelineCalls = 0
         val adapter = ComponentAotCliAdapter(
             compilerResolver = ComponentAotCompilerResolver { directory, version ->
-                assertEquals(fullCompiler.parentFile, directory)
+                assertEquals(componentCompiler.parentFile, directory)
                 resolvedVersion = version
-                fullCompiler
+                componentCompiler
             },
             pipelineRunner = ComponentAotPipelineRunner { capturedRaw, componentDirectory, request ->
                 pipelineCalls += 1
                 assertEquals(rawRecord, capturedRaw)
                 assertEquals(component.parentFile, componentDirectory)
-                assertEquals(fullCompiler, request.wasmtimeCompiler)
+                assertEquals(componentCompiler, request.wasmtimeCompiler)
                 val artifacts = request.targets.map { target ->
                     target.outputFile.writeBytes(target.target.encodeToByteArray())
                     val pulley = target.backend.artifactType == WasmlineArtifactType.PWASM
@@ -75,7 +75,7 @@ class ComponentAotCliSupportTest {
                 componentDirectory = component.parentFile,
                 outputDirectory = File(root, "aot"),
                 productName = "plugin",
-                wasmtimeDirectory = fullCompiler.parentFile,
+                wasmtimeDirectory = componentCompiler.parentFile,
                 targets = listOf("x86_64-linux", "pulley64"),
                 wasmtimeVersion = "47.0.2",
             ),
@@ -89,7 +89,7 @@ class ComponentAotCliSupportTest {
     }
 
     @Test
-    fun `rejects component aot when no full compiler matches`() = withCliAotDirectory { root ->
+    fun `rejects component aot when no compiler candidate matches`() = withCliAotDirectory { root ->
         val component = File(root, "plugin.component.wasm").apply { writeBytes(byteArrayOf(1)) }
         var pipelineCalls = 0
         val adapter = ComponentAotCliAdapter(
@@ -114,8 +114,8 @@ class ComponentAotCliSupportTest {
             )
         }
 
-        assertTrue(error.message.orEmpty().contains("full Wasmtime 47.0.2"))
-        assertTrue(error.message.orEmpty().contains("wasmtime-min is runtime-only"))
+        assertTrue(error.message.orEmpty().contains("Wasmtime 47.0.2 CLI"))
+        assertTrue(error.message.orEmpty().contains("minimal distribution"))
         assertEquals(0, pipelineCalls)
     }
 

--- a/wasmline-multiplatform/wasmline-gradle-plugin/src/main/kotlin/crow/wasmline/WasmlinePlugin.kt
+++ b/wasmline-multiplatform/wasmline-gradle-plugin/src/main/kotlin/crow/wasmline/WasmlinePlugin.kt
@@ -52,7 +52,7 @@ import kotlin.jvm.java
  *
  * Toolchain and signing tasks:
  * - `wasmlineDownloadWasmtime` — download wasmtime binary
- * - `wasmlineDownloadWasmtimeCompiler` — download the full Wasmtime CLI
+ * - `wasmlineDownloadWasmtimeCompiler` — download the minimal Cranelift Component AOT compiler
  * - `wasmlineDownloadComponentTools` — download Component Model tools
  * - `checkWasmlineToolchain` — verify wasmtime is available
  * - `generateWasmlineManifestKeyPairEd25519` — generate an Ed25519 manifest key pair
@@ -173,14 +173,14 @@ public class WasmlinePlugin : KotlinCompilerPluginSupportPlugin {
         }
         project.tasks.register("wasmlineDownloadWasmtimeCompiler", DownloadWasmtimeTask::class.java) { task ->
             task.group = "wasmline"
-            task.description = "Download the full Wasmtime CLI used for Component AOT compilation"
+            task.description = "Download the minimal Cranelift CLI used for Component AOT compilation"
             task.wasmtimeDirectory.set(ext.wasmtime.compilerDirectory)
             task.version.set(ext.wasmtime.compilerVersion)
             task.platform.convention(detectCurrentPlatform())
-            task.distribution.set(WasmtimeDistribution.FULL)
+            task.distribution.set(WasmtimeDistribution.MINIMAL)
             task.githubToken.set(ext.wasmtime.githubToken)
             task.installedExecutable.set(
-                ext.wasmtime.compilerDirectory.file(fullWasmtimeExecutableName()),
+                ext.wasmtime.compilerDirectory.file(minimalWasmtimeExecutableName()),
             )
         }
     }
@@ -367,8 +367,8 @@ public class WasmlinePlugin : KotlinCompilerPluginSupportPlugin {
 
     private fun detectCurrentPlatform(): String = PlatformDetector.detectPlatform()
 
-    private fun fullWasmtimeExecutableName(): String =
-        if (System.getProperty("os.name").lowercase().contains("win")) "wasmtime.exe" else "wasmtime"
+    private fun minimalWasmtimeExecutableName(): String =
+        if (System.getProperty("os.name").lowercase().contains("win")) "wasmtime-min.exe" else "wasmtime-min"
 
     private fun runCommand(command: List<String>): String = try {
         val process = ProcessBuilder(command).redirectErrorStream(true).start()
@@ -633,15 +633,15 @@ public class WasmlinePlugin : KotlinCompilerPluginSupportPlugin {
                     ext.wasmtime.compilerExecutable.orNull?.asFile ?: run {
                         val directory = ext.wasmtime.compilerDirectory.get().asFile
                         val version = ext.wasmtime.compilerVersion.get()
-                        WasmtimeCompiler.findWasmtimeCompilerInDirectory(
+                        WasmtimeCompiler.findComponentCompilerInDirectory(
                             baseDir = directory,
                             platform = detectCurrentPlatform(),
                             version = version,
                         ) ?: if (ext.wasmtime.autoDownload.get()) {
-                            File(directory, fullWasmtimeExecutableName())
+                            File(directory, minimalWasmtimeExecutableName())
                         } else {
                             throw GradleException(
-                                "Full Wasmtime CLI $version was not found in ${directory.absolutePath}. " +
+                                "A compile-capable Wasmtime CLI $version was not found in ${directory.absolutePath}. " +
                                     "Configure wasmline.wasmtime.compilerExecutable or run " +
                                     "./gradlew wasmlineDownloadWasmtimeCompiler.",
                             )

--- a/wasmline-multiplatform/wasmline-gradle-plugin/src/main/kotlin/crow/wasmline/gradle/extensions/WasmtimeExtension.kt
+++ b/wasmline-multiplatform/wasmline-gradle-plugin/src/main/kotlin/crow/wasmline/gradle/extensions/WasmtimeExtension.kt
@@ -117,16 +117,16 @@ public abstract class WasmtimeExtension @Inject constructor(objects: ObjectFacto
     public val version: Property<String> = objects.property(String::class.java)
         .convention("latest")
 
-    /** Exact full Wasmtime CLI version used only for Component AOT compilation. */
+    /** Exact Wasmtime CLI version used for Component AOT compilation. */
     public val compilerVersion: Property<String> = objects.property(String::class.java)
         .convention(ToolchainCatalog.WASMTIME_VERSION)
 
-    /** Separate cache root for the full build-time CLI; runtime-min remains in [directory]. */
+    /** Separate cache root for the Component AOT compiler. */
     public val compilerDirectory: DirectoryProperty = objects.directoryProperty().apply {
         set(File(System.getProperty("user.home"), ".wasmline/wasmtime-compiler"))
     }
 
-    /** Optional explicit full Wasmtime CLI executable. `wasmtime-min` is rejected. */
+    /** Optional Component AOT compiler override. Both compile-capable minimal and full CLIs are accepted. */
     public val compilerExecutable: RegularFileProperty = objects.fileProperty()
 
     /**

--- a/wasmline-multiplatform/wasmline-gradle-plugin/src/main/kotlin/crow/wasmline/gradle/tasks/DownloadWasmtimeTask.kt
+++ b/wasmline-multiplatform/wasmline-gradle-plugin/src/main/kotlin/crow/wasmline/gradle/tasks/DownloadWasmtimeTask.kt
@@ -93,7 +93,7 @@ public abstract class DownloadWasmtimeTask : DefaultTask() {
 
     private fun findExecutable(baseDir: File, platform: String, version: String, distribution: WasmtimeDistribution): File? =
         when (distribution) {
-            WasmtimeDistribution.MINIMAL -> WasmtimeCompiler.findWasmtimeInDirectory(baseDir, platform, version)
+            WasmtimeDistribution.MINIMAL -> WasmtimeCompiler.findWasmtimeMinimalInDirectory(baseDir, platform, version)
             WasmtimeDistribution.FULL -> WasmtimeCompiler.findWasmtimeCompilerInDirectory(baseDir, platform, version)
         }
 

--- a/wasmline-multiplatform/wasmline-gradle-plugin/src/test/kotlin/crow/wasmline/gradle/tasks/WasmlineComponentAotRegistrationTest.kt
+++ b/wasmline-multiplatform/wasmline-gradle-plugin/src/test/kotlin/crow/wasmline/gradle/tasks/WasmlineComponentAotRegistrationTest.kt
@@ -18,14 +18,14 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalWasmDsl::class)
 class WasmlineComponentAotRegistrationTest {
     @Test
-    fun registersFullCompilerDownloadAndVariantAotTasks() = withRegistrationDirectory { root ->
+    fun registersMinimalCompilerDownloadAndVariantAotTasks() = withRegistrationDirectory { root ->
         val project = ProjectBuilder.builder().withProjectDir(root).build()
         project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
         project.pluginManager.apply(WasmlinePlugin::class.java)
         val extension = project.extensions.getByType(WasmlineExtension::class.java)
         val explicitCompiler = File(root, "tools/wasmtime").apply {
             parentFile.mkdirs()
-            writeText("full compiler")
+            writeText("component compiler")
         }
         extension.manifest.pluginId.set("crow.test.plugin")
         extension.wasmtime.compilerExecutable.set(explicitCompiler)
@@ -43,8 +43,14 @@ class WasmlineComponentAotRegistrationTest {
         val debugAot = project.tasks.named("wasmlineComponentAotDebug", WasmlineComponentAotTask::class.java).get()
         val releaseAot = project.tasks.named("wasmlineComponentAotRelease", WasmlineComponentAotTask::class.java).get()
 
-        assertEquals(WasmtimeDistribution.FULL, compilerDownload.distribution.get())
+        assertEquals(WasmtimeDistribution.MINIMAL, compilerDownload.distribution.get())
         assertEquals(WasmtimeDistribution.MINIMAL, minimalDownload.distribution.get())
+        val expectedCompilerName = if (System.getProperty("os.name").lowercase().contains("win")) {
+            "wasmtime-min.exe"
+        } else {
+            "wasmtime-min"
+        }
+        assertEquals(expectedCompilerName, compilerDownload.installedExecutable.get().asFile.name)
         assertEquals(ToolchainCatalog.WASMTIME_VERSION, debugAot.wasmtimeVersion.get())
         assertEquals(explicitCompiler.canonicalFile, debugAot.wasmtimeCompilerExecutable.get().asFile.canonicalFile)
         assertEquals(listOf("pulley64", "aarch64-linux"), debugAot.targets.get())
@@ -55,7 +61,7 @@ class WasmlineComponentAotRegistrationTest {
     }
 
     @Test
-    fun autoDownloadAddsOnlyTheFullCompilerDownloadDependency() = withRegistrationDirectory { root ->
+    fun autoDownloadAddsOnlyTheComponentCompilerDownloadDependency() = withRegistrationDirectory { root ->
         val project = ProjectBuilder.builder().withProjectDir(root).build()
         project.pluginManager.apply("org.jetbrains.kotlin.multiplatform")
         project.pluginManager.apply(WasmlinePlugin::class.java)
@@ -76,7 +82,7 @@ class WasmlineComponentAotRegistrationTest {
         project.pluginManager.apply(WasmlinePlugin::class.java)
         val extension = project.extensions.getByType(WasmlineExtension::class.java)
         extension.manifest.executionModel.set(WasmlineExecutionModel.COMPONENT_MODEL)
-        extension.wasmtime.compilerExecutable.set(File(root, "wasmtime").apply { writeText("full compiler") })
+        extension.wasmtime.compilerExecutable.set(File(root, "wasmtime-min").apply { writeText("component compiler") })
         project.extensions.getByType(KotlinMultiplatformExtension::class.java).wasmWasi()
         WasmlinePlugin().configureAssembleTaskGraph(project, extension)
 

--- a/wasmline-multiplatform/wasmline-plugin-core/src/main/kotlin/crow/wasmline/plugin/core/compiler/WasmtimeCompiler.kt
+++ b/wasmline-multiplatform/wasmline-plugin-core/src/main/kotlin/crow/wasmline/plugin/core/compiler/WasmtimeCompiler.kt
@@ -87,7 +87,48 @@ class WasmtimeCompiler {
                 ?.firstOrNull { matchesVersion(it, version) }
         }
 
-        /** Finds only the full build-time Wasmtime CLI, never wasmtime-min. */
+        /** Finds a minimal cache alias or the reduced Cranelift release used by download tasks. */
+        fun findWasmtimeMinimalInDirectory(baseDir: File, platform: String? = null, version: String? = null): File? {
+            findDirectWasmtimeMinimalExecutable(baseDir)?.let { executable ->
+                if (matchesVersion(executable, version)) return executable
+            }
+            if (!baseDir.isDirectory) return null
+
+            return baseDir.listFiles()
+                ?.asSequence()
+                ?.filter(File::isDirectory)
+                ?.filter { platform == null || it.name.contains(platform) }
+                ?.filter(::isCraneliftMinimalReleaseDirectory)
+                ?.sortedByDescending(File::getName)
+                ?.mapNotNull(::findWasmtimeExecutable)
+                ?.firstOrNull { matchesVersion(it, version) }
+        }
+
+        /**
+         * Finds a Component AOT compiler candidate from an installed executable or release directory.
+         * Cranelift minimal releases are preferred over full Cranelift and Pulley releases.
+         * ComponentCompiler verifies the compile subcommand before using the executable.
+         */
+        fun findComponentCompilerInDirectory(baseDir: File, platform: String? = null, version: String? = null): File? {
+            findDirectWasmtimeExecutable(baseDir)?.let { executable ->
+                if (matchesVersion(executable, version)) return executable
+            }
+            if (!baseDir.isDirectory) return null
+
+            return baseDir.listFiles()
+                ?.asSequence()
+                ?.filter(File::isDirectory)
+                ?.filter { platform == null || it.name.contains(platform) }
+                ?.filterNot { it.name.contains("c-api", ignoreCase = true) }
+                ?.sortedWith(
+                    compareBy<File>(::componentCompilerDirectoryPriority)
+                        .thenByDescending(File::getName),
+                )
+                ?.mapNotNull(::findWasmtimeExecutable)
+                ?.firstOrNull { matchesVersion(it, version) }
+        }
+
+        /** Finds a direct Wasmtime override or a full Cranelift release candidate. */
         fun findWasmtimeCompilerInDirectory(baseDir: File, platform: String? = null, version: String? = null): File? {
             findDirectWasmtimeCompilerExecutable(baseDir)?.let { executable ->
                 if (matchesVersion(executable, version)) return executable
@@ -98,6 +139,7 @@ class WasmtimeCompiler {
                 ?.asSequence()
                 ?.filter(File::isDirectory)
                 ?.filter { platform == null || it.name.contains(platform) }
+                ?.filter(::isFullCraneliftReleaseDirectory)
                 ?.sortedByDescending(File::getName)
                 ?.mapNotNull(::findWasmtimeCompilerExecutable)
                 ?.firstOrNull { matchesVersion(it, version) }
@@ -114,7 +156,7 @@ class WasmtimeCompiler {
                     ?.firstOrNull()
         }
 
-        /** Finds a full Wasmtime CLI below the given directory. */
+        /** Finds the executable layout used by a preselected full Wasmtime CLI archive. */
         fun findWasmtimeCompilerExecutable(directory: File): File? {
             if (!directory.exists()) return null
             return findDirectWasmtimeCompilerExecutable(directory)
@@ -145,6 +187,33 @@ class WasmtimeCompiler {
             return directory.listFiles()
                 ?.firstOrNull { it.isFile && it.name.equals(targetName, ignoreCase = true) }
                 ?.also { executable -> if (!isWindows) executable.setExecutable(true) }
+        }
+
+        private fun findDirectWasmtimeMinimalExecutable(directory: File): File? {
+            val isWindows = System.getProperty("os.name").lowercase().contains("win")
+            val targetName = if (isWindows) "wasmtime-min.exe" else "wasmtime-min"
+            return directory.listFiles()
+                ?.firstOrNull { it.isFile && it.name.equals(targetName, ignoreCase = true) }
+                ?.also { executable -> if (!isWindows) executable.setExecutable(true) }
+        }
+
+        private fun componentCompilerDirectoryPriority(directory: File): Int {
+            val name = directory.name.lowercase()
+            return when {
+                "-pulley" in name -> 2
+                "-min" in name -> 0
+                else -> 1
+            }
+        }
+
+        private fun isFullCraneliftReleaseDirectory(directory: File): Boolean {
+            val name = directory.name.lowercase()
+            return "-min" !in name && "-pulley" !in name && "c-api" !in name
+        }
+
+        private fun isCraneliftMinimalReleaseDirectory(directory: File): Boolean {
+            val name = directory.name.lowercase()
+            return "-min" in name && "-pulley" !in name && "c-api" !in name
         }
 
         private fun matchesVersion(executable: File, requestedVersion: String?): Boolean {

--- a/wasmline-multiplatform/wasmline-plugin-core/src/main/kotlin/crow/wasmline/plugin/core/component/ComponentCompiler.kt
+++ b/wasmline-multiplatform/wasmline-plugin-core/src/main/kotlin/crow/wasmline/plugin/core/component/ComponentCompiler.kt
@@ -8,7 +8,7 @@ import crow.wasmline.plugin.core.toolchain.FileDigest
 import crow.wasmline.plugin.core.toolchain.ToolExecutionResult
 import java.io.File
 
-/** Executes the full Wasmtime CLI to create native Component AOT artifacts. */
+/** Executes a compile-capable Wasmtime CLI to create native Component AOT artifacts. */
 
 @InternalWasmlineToolingApi
 class ComponentCompiler internal constructor(private val runner: ComponentCompilerToolRunner) {
@@ -37,9 +37,6 @@ class ComponentCompiler internal constructor(private val runner: ComponentCompil
         }
         require(request.wasmtimeCompiler.canExecute()) {
             "Wasmtime compiler is not executable: " + request.wasmtimeCompiler.absolutePath
-        }
-        require(!request.wasmtimeCompiler.nameWithoutExtension.equals("wasmtime-min", ignoreCase = true)) {
-            "Component AOT compilation requires the full Wasmtime CLI; wasmtime-min is runtime-only."
         }
         require(request.inputComponent.isFile && request.inputComponent.length() > 0) {
             "Component Wasm input does not exist or is empty: " + request.inputComponent.absolutePath
@@ -74,7 +71,13 @@ class ComponentCompiler internal constructor(private val runner: ComponentCompil
     }
 
     private fun verifyComponentCompileSupport(executable: File) {
-        runChecked(executable, listOf("compile", "--help"))
+        val result = runner.run(executable, listOf("compile", "--help"))
+        check(result.exitCode == 0) {
+            "Wasmtime executable does not provide the compile subcommand required for Component AOT " +
+                "(exit code ${result.exitCode}): " +
+                executable.absolutePath +
+                if (result.output.isBlank()) "" else System.lineSeparator() + result.output
+        }
     }
 
     private fun compileTarget(request: ComponentAotCompileRequest, target: ComponentAotTarget): ComponentAotCompileOutput {

--- a/wasmline-multiplatform/wasmline-plugin-core/src/main/kotlin/crow/wasmline/plugin/core/component/ComponentCompilerModels.kt
+++ b/wasmline-multiplatform/wasmline-plugin-core/src/main/kotlin/crow/wasmline/plugin/core/component/ComponentCompilerModels.kt
@@ -91,7 +91,7 @@ data class ComponentAotTarget(val target: String, val backend: ComponentAotBacke
     }
 }
 
-/** Inputs for compiling a finished Component Wasm with the full Wasmtime CLI. */
+/** Inputs for compiling a finished Component Wasm with a compile-capable Wasmtime CLI. */
 
 @InternalWasmlineToolingApi
 data class ComponentAotCompileRequest(

--- a/wasmline-multiplatform/wasmline-plugin-core/src/main/kotlin/crow/wasmline/plugin/core/download/WasmtimeDownloader.kt
+++ b/wasmline-multiplatform/wasmline-plugin-core/src/main/kotlin/crow/wasmline/plugin/core/download/WasmtimeDownloader.kt
@@ -22,7 +22,7 @@ import java.nio.file.StandardCopyOption
 import java.util.zip.GZIPInputStream
 import java.util.zip.ZipInputStream
 
-/** Selects either the runtime-only asset or the full build-time Wasmtime CLI. */
+/** Selects either the reduced Cranelift CLI or the full Cranelift fallback CLI. */
 
 @InternalWasmlineToolingApi
 enum class WasmtimeDistribution {

--- a/wasmline-multiplatform/wasmline-plugin-core/src/test/kotlin/crow/wasmline/plugin/core/compiler/WasmtimeCompilerTest.kt
+++ b/wasmline-multiplatform/wasmline-plugin-core/src/test/kotlin/crow/wasmline/plugin/core/compiler/WasmtimeCompilerTest.kt
@@ -78,6 +78,143 @@ class WasmtimeCompilerTest {
         }
     }
 
+    @Test
+    fun fullCompilerDiscoveryRejectsCraneliftMinimalReleaseDirectory() {
+        val root = createTempDirectory("wasmtime-min-release").toFile()
+        try {
+            executable(
+                File(root, "wasmtime-v47.0.2-x86_64-linux-min/${executableName(minimal = false)}").apply {
+                    parentFile.mkdirs()
+                },
+            )
+
+            assertNull(WasmtimeCompiler.findWasmtimeCompilerInDirectory(root))
+        } finally {
+            root.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun minimalCompilerDiscoverySelectsOnlyCraneliftMinimalRelease() {
+        val root = createTempDirectory("wasmtime-minimal-release").toFile()
+        try {
+            val executableName = executableName(minimal = false)
+            val minimal = executable(
+                File(root, "wasmtime-v47.0.2-x86_64-linux-min/$executableName").apply {
+                    parentFile.mkdirs()
+                },
+            )
+            executable(
+                File(root, "wasmtime-v47.0.2-x86_64-linux/$executableName").apply {
+                    parentFile.mkdirs()
+                },
+            )
+            executable(
+                File(root, "wasmtime-v47.0.2-x86_64-linux-pulley/$executableName").apply {
+                    parentFile.mkdirs()
+                },
+            )
+
+            assertEquals(
+                minimal.canonicalFile,
+                WasmtimeCompiler.findWasmtimeMinimalInDirectory(root)?.canonicalFile,
+            )
+        } finally {
+            root.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun minimalCompilerDiscoveryRejectsFullReleaseDirectory() {
+        val root = createTempDirectory("wasmtime-full-release").toFile()
+        try {
+            executable(
+                File(root, "wasmtime-v47.0.2-x86_64-linux/${executableName(minimal = false)}").apply {
+                    parentFile.mkdirs()
+                },
+            )
+
+            assertNull(WasmtimeCompiler.findWasmtimeMinimalInDirectory(root))
+        } finally {
+            root.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun componentCompilerDiscoveryPrefersCraneliftMinimalRelease() {
+        val root = createTempDirectory("wasmtime-component-compiler").toFile()
+        try {
+            val executableName = executableName(minimal = false)
+            val minimal = executable(
+                File(root, "wasmtime-v47.0.2-x86_64-linux-min/$executableName").apply {
+                    parentFile.mkdirs()
+                },
+            )
+            executable(
+                File(root, "wasmtime-v47.0.2-x86_64-linux/$executableName").apply {
+                    parentFile.mkdirs()
+                },
+            )
+            executable(
+                File(root, "wasmtime-v47.0.2-x86_64-linux-pulley/$executableName").apply {
+                    parentFile.mkdirs()
+                },
+            )
+
+            assertEquals(
+                minimal.canonicalFile,
+                WasmtimeCompiler.findComponentCompilerInDirectory(root)?.canonicalFile,
+            )
+        } finally {
+            root.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun componentCompilerDiscoveryPrefersCraneliftFullOverPulleyFull() {
+        val root = createTempDirectory("wasmtime-component-compiler-full").toFile()
+        try {
+            val executableName = executableName(minimal = false)
+            val full = executable(
+                File(root, "wasmtime-v47.0.2-x86_64-linux/$executableName").apply {
+                    parentFile.mkdirs()
+                },
+            )
+            executable(
+                File(root, "wasmtime-v47.0.2-x86_64-linux-pulley/$executableName").apply {
+                    parentFile.mkdirs()
+                },
+            )
+
+            assertEquals(
+                full.canonicalFile,
+                WasmtimeCompiler.findComponentCompilerInDirectory(root)?.canonicalFile,
+            )
+        } finally {
+            root.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun componentCompilerDiscoveryAcceptsPulleyFullAsLastFallback() {
+        val root = createTempDirectory("wasmtime-component-compiler-pulley").toFile()
+        try {
+            val executableName = executableName(minimal = false)
+            val pulley = executable(
+                File(root, "wasmtime-v47.0.2-x86_64-linux-pulley/$executableName").apply {
+                    parentFile.mkdirs()
+                },
+            )
+
+            assertEquals(
+                pulley.canonicalFile,
+                WasmtimeCompiler.findComponentCompilerInDirectory(root)?.canonicalFile,
+            )
+        } finally {
+            root.deleteRecursively()
+        }
+    }
+
     private fun executableName(minimal: Boolean): String {
         val suffix = if (System.getProperty("os.name").lowercase().contains("win")) ".exe" else ""
         return "wasmtime" + (if (minimal) "-min" else "") + suffix

--- a/wasmline-multiplatform/wasmline-plugin-core/src/test/kotlin/crow/wasmline/plugin/core/component/ComponentCompilerTest.kt
+++ b/wasmline-multiplatform/wasmline-plugin-core/src/test/kotlin/crow/wasmline/plugin/core/component/ComponentCompilerTest.kt
@@ -63,19 +63,38 @@ class ComponentCompilerTest {
     }
 
     @Test
-    fun rejectsWasmtimeMinBeforeRunningIt() = withCompilerDirectory { root ->
+    fun acceptsWasmtimeMinWhenCompileSubcommandIsAvailable() = withCompilerDirectory { root ->
         val compilerFile = executable(File(root, "wasmtime-min"))
         val input = File(root, "plugin-component.wasm").apply { writeBytes(byteArrayOf(1)) }
-        val runner = RecordingComponentCompilerRunner()
-
-        val error = assertFailsWith<IllegalArgumentException> {
-            ComponentCompiler(runner).compile(
-                request(compilerFile, input, File(root, "plugin.cwasm")),
-            )
+        val output = File(root, "plugin.cwasm")
+        val runner = RecordingComponentCompilerRunner { arguments ->
+            if (arguments.firstOrNull() == "compile" && arguments.getOrNull(1) != "--help") {
+                output.writeBytes(byteArrayOf(2, 3))
+            }
         }
 
-        assertTrue(error.message.orEmpty().contains("full Wasmtime CLI"))
-        assertTrue(runner.arguments.isEmpty())
+        val result = ComponentCompiler(runner).compile(request(compilerFile, input, output))
+
+        assertEquals(output, result.outputs.single().outputFile)
+        assertEquals(listOf("--version"), runner.arguments[0])
+        assertEquals(listOf("compile", "--help"), runner.arguments[1])
+        assertEquals(3, runner.arguments.size)
+    }
+
+    @Test
+    fun rejectsWasmtimeWithoutCompileSubcommand() = withCompilerDirectory { root ->
+        val compilerFile = executable(File(root, "wasmtime-min"))
+        val input = File(root, "plugin-component.wasm").apply { writeBytes(byteArrayOf(1)) }
+        val runner = RecordingComponentCompilerRunner(
+            exitCode = { arguments -> if (arguments == listOf("compile", "--help")) 2 else 0 },
+        )
+
+        val error = assertFailsWith<IllegalStateException> {
+            ComponentCompiler(runner).compile(request(compilerFile, input, File(root, "plugin.cwasm")))
+        }
+
+        assertTrue(error.message.orEmpty().contains("does not provide the compile subcommand"))
+        assertEquals(listOf(listOf("--version"), listOf("compile", "--help")), runner.arguments)
     }
 
     @Test

--- a/wasmline-multiplatform/wasmline-plugin-core/src/test/kotlin/crow/wasmline/plugin/core/download/WasmtimeDistributionTest.kt
+++ b/wasmline-multiplatform/wasmline-plugin-core/src/test/kotlin/crow/wasmline/plugin/core/download/WasmtimeDistributionTest.kt
@@ -17,11 +17,18 @@ class WasmtimeDistributionTest {
     }
 
     @Test
-    fun excludesCApiPulleyAndOtherPlatformsForBothDistributions() {
+    fun excludesCApiPulleyVariantsAndOtherPlatformsForBothDistributions() {
         listOf(WasmtimeDistribution.MINIMAL, WasmtimeDistribution.FULL).forEach { distribution ->
             assertFalse(
                 matchesWasmtimeDistributionAsset(
                     "wasmtime-v47.0.2-x86_64-linux-c-api.tar.xz",
+                    "x86_64-linux",
+                    distribution,
+                ),
+            )
+            assertFalse(
+                matchesWasmtimeDistributionAsset(
+                    "wasmtime-v47.0.2-x86_64-linux-pulley-min-c-api.tar.xz",
                     "x86_64-linux",
                     distribution,
                 ),

--- a/wasmline-multiplatform/wasmline-plugin-core/src/test/kotlin/crow/wasmline/plugin/core/download/WasmtimeDownloaderTest.kt
+++ b/wasmline-multiplatform/wasmline-plugin-core/src/test/kotlin/crow/wasmline/plugin/core/download/WasmtimeDownloaderTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertNotNull
 
 class WasmtimeDownloaderTest {
     @Test
-    fun minimalDistributionAcceptsRuntimeExecutableWithoutMinSuffix() {
+    fun minimalDistributionAcceptsCliExecutableWithoutMinSuffix() {
         val root = createTempDirectory("wasmtime-downloader").toFile()
         try {
             val extracted = root.resolve("wasmtime-v47.0.2-x86_64-linux-min").apply { mkdirs() }

--- a/wasmline-samples/kotlin/README.md
+++ b/wasmline-samples/kotlin/README.md
@@ -51,9 +51,9 @@ Assemble them independently:
 ./gradlew :sample-component-export-plugin:wasmlineAssembleDebug
 ```
 
-Component AOT requires the full Wasmtime CLI. The Gradle plugin downloads its
-pinned compiler automatically for Component package tasks; no shell export is
-required.
+Component AOT uses the fork's compile-capable `cranelift-min` CLI by default.
+The Gradle plugin downloads the pinned compiler automatically for Component
+package tasks; full CLIs remain explicit fallbacks and no shell export is required.
 
 ```shell
 ./gradlew :sample-component-plugin:wasmlineAssembleDebug

--- a/wasmline-samples/kotlin/sample-apps/README.md
+++ b/wasmline-samples/kotlin/sample-apps/README.md
@@ -37,7 +37,7 @@ plugin, selects the requested artifact, and runs the host application:
 
 Use `-Pwasmline.artifact.format=pwasm32` only with a 32-bit native runtime;
 the current 64-bit desktop runtime rejects it by design. Component AOT builds
-download the pinned full Wasmtime CLI automatically through the Gradle plugin.
+download the pinned `cranelift-min` Wasmtime CLI automatically through the Gradle plugin.
 
 Desktop uses one signed `manifest.wlm` per mode. The host configures the sample
 public key, and the loader selects the compatible artifact after verifying the

--- a/wasmline-samples/kotlin/sample-component-plugin/README.md
+++ b/wasmline-samples/kotlin/sample-component-plugin/README.md
@@ -19,9 +19,9 @@ The task chain materializes Wasmline's canonical WIT, generates Kotlin bindings 
 Wasmline transport adapter under `build/generated`, compiles the
 Kotlin/Wasm WASI library with JDK 21, embeds WIT, creates and validates the
 Component with the pinned `wit-bindgen` 0.57.1 and `wasm-tools` 1.256.0, then
-uses the full Wasmtime CLI to produce matching `.pwasm` and `.cwasm` Component
+uses the fork's `cranelift-min` CLI to produce matching `.pwasm` and `.cwasm` Component
 artifacts. Generated bindings and intermediate Wasm files are build outputs and
-are not committed. The Gradle plugin downloads the pinned full Wasmtime CLI
+are not committed. The Gradle plugin downloads the pinned minimal Wasmtime CLI
 automatically when the compiler is not already available.
 
 The guest never imports generated `Host`/`Plugin` types directly and does not maintain an


### PR DESCRIPTION
## Summary

- Use the forked Cranelift minimal CLI by default for Component AOT downloads and cache it under the minimal executable alias.
- Resolve compiler candidates in the order Cranelift minimal, full Cranelift, then full Pulley while excluding C API-only assets.
- Validate Component compilation through the exact version and `compile` subcommand instead of the executable filename.
- Update tests, samples, and English and Chinese documentation for the minimal-first behavior and full CLI fallbacks.

## Validation

- `bash scripts/lint.sh`
- `git diff --check`
- `pnpm --dir docs run types:check`
- `pnpm --dir docs run build`
- Gradle tests not run (not requested; repository rules require explicit authorization).